### PR TITLE
Fix a bug that broke Google's GeoJSON parsing

### DIFF
--- a/lib/geometry/Point.class.php
+++ b/lib/geometry/Point.class.php
@@ -147,7 +147,7 @@ class Point extends Geometry {
 		$coords = $this->coords;
 
 		if (! isset( $coords[2] ) ) {
-			$coords[2] = NULL;
+			$coords[2] = 0;
 		}
 
 		if (( $metadata = $this->getMetaData() ) != NULL ) {

--- a/tests/tests/kmlToGeoJsonTest.php
+++ b/tests/tests/kmlToGeoJsonTest.php
@@ -1,0 +1,13 @@
+<?php
+require_once('../geoPHP.inc');
+class KmlToGeoJsonTest extends PHPUnit_Framework_TestCase {
+
+  function testThirdDimensionIsZeroInsteadOfNull() {
+    $geometry = geoPHP::load(file_get_contents('./input/cdata.kml'), 'kml');
+
+    $results = $geometry->out('json', $returnArray = true);
+
+    $this->assertNotSame(null, $results['features'][0]['geometry']['coordinates'][2], 'value can NOT be null per the GeoJson spec');
+    $this->assertSame(0, $results['features'][0]['geometry']['coordinates'][2], 'set this to a zero value');
+  }
+}


### PR DESCRIPTION
When converting from a KML file to a GeoJSON file, the coordinates array for points ended up looking like this:

```
[coordinates] => Array
(
  [0] => 102.595626
  [1] => 14.996729
  [2] => 
)
```

Feeding those results to Google Maps lead to errors. Per the GeoJSON spec, values can't be null. With this patch, coordinates come out as:

```
[coordinates] => Array
(
  [0] => 102.595626
  [1] => 14.996729
  [2] => 0
)
```

and then work properly. I'm not seeing any other tests failing, but it's possible this will cause problems for other conversions if some other formats expect a NULL value ...