### PR TITLE
issue #21 - fixed tag ordering when no metadata. Updated tests.

### DIFF
--- a/tests/tests/adaptersTest.php
+++ b/tests/tests/adaptersTest.php
@@ -25,6 +25,8 @@ class AdaptersTests extends PHPUnit_Framework_TestCase {
               $test_geom_1 = $adapter_loader->read($output);
               $test_geom_2 = $adapter_loader->read($test_geom_1->out($adapter_key));
               $this->assertEquals($test_geom_1->out('wkt'), $test_geom_2->out('wkt'), "Mismatched adapter output in ".$adapter_class  .' (test file: ' . $file . ')');
+
+
             }
           }
         }
@@ -54,6 +56,7 @@ class AdaptersTests extends PHPUnit_Framework_TestCase {
 
               // Check to make sure a both are the same with geos and without
               $this->assertEquals($test_geom_1->out('wkt'), $test_geom_2->out('wkt'), "Mismatched adapter output between GEOS and NORM in ".$adapter_class .' (test file: ' . $file . ')');
+
             }
           }
         }


### PR DESCRIPTION
Updated tests to avoid generating GPX files when there are polygons in the data. GPX does not support polygons.